### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ virtualenv.
 
 ### Install
 
-    $ curl https://raw.github.com/HubSpot/virtualenvchdir/master/virtualenvchdir.sh > ~/.virtualenvchdir.sh
+    $ curl -L https://raw.github.com/HubSpot/virtualenvchdir/master/virtualenvchdir.sh > ~/.virtualenvchdir.sh
     $ echo ". ~/.virtualenvchdir.sh" >> ~/.bash_profile # (bash)
     $ echo ". ~/.virtualenvchdir.sh" >> ~/.zshrc # (zsh)
 


### PR DESCRIPTION
-L flag to follow redirects to make url a bit more future proof (Since it now redirects to  https://raw.githubusercontent.com/HubSpot/virtualenvchdir/master/virtualenvchdir.sh)

Without this , the instructions create an empty file, instead of downloading the script.
